### PR TITLE
Fix a couple of minor bugs that can cause NaN values

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,9 +125,10 @@ function generateRecipe(ingredients, nutrientTargets) {
     // Fetch the target values ignoring the "max" values and any nonnumerical variables
     for (var key in nutrientTargets) {
         var name = key,
+            nutrient = name.replace(/_max$/, '')
             value = nutrientTargets[key];
 
-        if (name != "name" && name.substring(name.length - 4, name.length) != "_max" && value > 0) {
+        if (nutrients.indexOf(nutrient) > -1 && name.substring(name.length - 4, name.length) != "_max" && value > 0) {
             targetName.push(name);
             targetAmount.push(value);
         }
@@ -318,7 +319,7 @@ request.get(recipeUrl + "/json?nutrientProfile=51e4e6ca7789bc0200000007", functi
         // Add up the amount of the current nutrient in each of the ingredients.
         var nutrientInIngredients = 0;
         for (j=0; j< ingredients.length; j++) {
-            if (typeof ingredients[j][nutrient] == 'number') {
+            if (typeof ingredients[j][nutrient] == 'number' && ingredientQuantities[j] > 0) {
                 nutrientInIngredients += ingredients[j][nutrient] * ingredientQuantities[j] / ingredients[j].serving;
             }
         }


### PR DESCRIPTION
I was having trouble running this against my recipe (http://diy.soylent.me/recipes/oats-whey-n-maltodextrin/json?nutrientProfile=5330c6e624b6250200777ec5) - didn't look too deeply but it seems `generateRecipe` was iterating over non-nutrient keys, causing `NaN` values to propagate.

The last change is needed when the algorithm decides to use "0" of an ingredient, otherwise everything ends up `NaN`.
